### PR TITLE
docs(readme): Update AngularFire library size

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | -------------         |:-------------:|         :-------------------:  |
 | Authentication        | :heavy_check_mark:    | :heavy_check_mark:     |
 | Firestore             | :heavy_check_mark:    |  :heavy_check_mark:    |
-| Storage               | :heavy_check_mark:    |  :x:                   |
+| Storage               | :heavy_check_mark:    |  :heavy_check_mark:    |
 | Realtime Database     | :heavy_check_mark:    |  :heavy_check_mark:    |
 | Cloud Messaging       | :heavy_check_mark:    |  :x:                   |
 | Server Side Rendering | :heavy_check_mark:    |  :x:                   |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | Cloud Messaging       | :heavy_check_mark:    |  :x:                   |
 | Server Side Rendering | :heavy_check_mark:    |  :x:                   |
 | Transactions and Batched Writes | :heavy_check_mark: <br> Observable Based    |  :x:  |
-| Package Size | <a href="https://arve0.github.io/npm-download-size/#angularfire-lite" target="blank">**76 KB**</a> :zap: | <a href="https://arve0.github.io/npm-download-size/#angularfire2" target="blank">**115 KB**</a> :turtle: |
+| Package Size | <a href="https://arve0.github.io/npm-download-size/#angularfire-lite" target="blank">**76 KB**</a> :zap: | <a href="https://arve0.github.io/npm-download-size/#angularfire2" target="blank">**12.9 KB (gzipped)**</a> |
 
 [![angluarfire-lite-ssr](https://cdn.rawgit.com/hamedbaatour/34003410a08925cb4301ce06fbc3936e/raw/91e29b8e406bb37404ab943519c374f1247957ec/SSR.svg)](#)
 ### Finally SSR with Firebase!


### PR DESCRIPTION
Hey @hamedbaatour! I have updated AngularFire to the proper library size. I used the files gzipped but I you want ungzipped I can provide that was well.

Also, AngularFire is broken up into separate modules so it's not necessarily 12.9kb that you'll use. Perhaps we should expand the table row to show each module's size.

Does AngularFire-Lite break each feature into a separate NgModule?

**Update**: I just realized you are using the tarball of the npm module to measure size. This isn't an accurate form of measurement as not everything shipping in the tarball is incldued in your app. AngularFire ships the documentation, README, multiple tsconfigs and package.json files. If we want to measure size, I recommend we use the minified and compressed UMD bundle size of each feature module. Does that sound good?
 