### PR TITLE
currentUser doesn't emit any value

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Subject } from 'rxjs/Subject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
 import { fromPromise } from 'rxjs/observable/fromPromise';
 import { AngularFireLiteApp } from '../core.service';
@@ -57,8 +58,8 @@ export class AngularFireLiteAuth {
   }
 
 
-  currentUser(): Subject<any> {
-    const CURRENT_USER = new Subject();
+  currentUser(): BehaviorSubject<any> {
+    const CURRENT_USER = new BehaviorSubject();
     CURRENT_USER.next(this.auth.currentUser);
     return CURRENT_USER;
   }


### PR DESCRIPTION
In Auth service, `currentUser ` does not emit any value, since the subject is returned after emitting. It can be solved easily changing it by a `BehaviorSubject`.

Another option would be just returning:

```js
return of(this.auth.currentUser);
```